### PR TITLE
Add Codex upgrade task and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ If you edit features or the provisioning script:
 devcontainer rebuild
 ```
 
+To refresh the Codex CLI without a rebuild:
+```bash
+task upgrade:codex
+```
+
 ## Environment Initialization (Baseline PATH Guarantee)
 
 Core tooling (Go, user-local bins) is available in every shell mode (login / non-login, interactive / non-interactive) through a layered, idempotent design:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,3 +9,8 @@ tasks:
     cmds:
       - devcontainer up --workspace-folder . --remove-existing-container --log-level trace
     silent: false
+  upgrade:codex:
+    desc: Download and install the latest Codex CLI without rebuilding the container
+    cmds:
+      - ./scripts/upgrade-codex.sh
+    silent: false


### PR DESCRIPTION
## Summary
- add a reusable script that fetches and installs the latest Codex CLI release in-place
- wire the script into a new `upgrade:codex` task and document how to run it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec8bd1a54832f9e8fa62981c94849