### PR TITLE
Add Ruby feature and install Rails in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,6 +39,9 @@
       "version": "latest",
       "installTools": true
     },
+    "ghcr.io/devcontainers/features/ruby:1": {
+      "version": "latest"
+    },
     "ghcr.io/devcontainers/features/rust:1": {
       "version": "latest"
     },

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -210,4 +210,20 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 
+# Install Rails when Ruby is available
+if command -v gem >/dev/null 2>&1; then
+  if ! command -v rails >/dev/null 2>&1; then
+    echo "🚂 Installing Rails (Ruby on Rails)"
+    if gem install rails --no-document; then
+      echo "  ✅ Rails installed"
+    else
+      echo "  ⚠ Failed to install Rails" >&2
+    fi
+  else
+    echo "🚂 Rails already available"
+  fi
+else
+  echo "  ⚠ RubyGems not available; skipping Rails install" >&2
+fi
+
 echo "✅ post-create complete"


### PR DESCRIPTION
## Summary
- add the official Ruby devcontainer feature to the base container definition
- install the Rails gem during post-create provisioning when RubyGems is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d047ba244c832fbecc62fc450d5b5c