### PR TITLE
Fix Claude CLI upgrade permissions

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -26,6 +26,45 @@ ensure_user_dir() {
   mkdir -p "$dir" 2>/dev/null || true
 }
 
+repair_claude_install_permissions() {
+  if ! command -v claude >/dev/null 2>&1; then
+    return
+  fi
+
+  user_name="$(id -un)"
+  group_name="$(id -gn)"
+  claude_bin="$(command -v claude)"
+
+  echo "🤖 Repairing Claude CLI ownership for self-upgrades"
+
+  fix_owner() {
+    path="$1"
+    [ -e "$path" ] || return
+    if [ -n "$SUDO" ]; then
+      $SUDO chown -R "${user_name}:${group_name}" "$path" 2>/dev/null || true
+    else
+      chown -R "${user_name}:${group_name}" "$path" 2>/dev/null || true
+    fi
+  }
+
+  # Binary path can be a symlink into NVM/global npm directories.
+  fix_owner "$claude_bin"
+  if command -v readlink >/dev/null 2>&1; then
+    resolved_bin="$(readlink -f "$claude_bin" 2>/dev/null || true)"
+    [ -n "${resolved_bin:-}" ] && fix_owner "$resolved_bin"
+  fi
+
+  if command -v npm >/dev/null 2>&1; then
+    npm_prefix="$(npm config get prefix 2>/dev/null || true)"
+    npm_root_global="$(npm root -g 2>/dev/null || true)"
+    [ -n "${npm_prefix:-}" ] && fix_owner "$npm_prefix"
+    if [ -n "${npm_root_global:-}" ]; then
+      fix_owner "$npm_root_global"
+      fix_owner "${npm_root_global}/@anthropic-ai"
+    fi
+  fi
+}
+
 ensure_login_shell() {
   desired_shell="/usr/bin/zsh"
   command -v chsh >/dev/null 2>&1 || return
@@ -283,6 +322,10 @@ EOF
 if command -v corepack >/dev/null 2>&1; then
   corepack enable >/dev/null 2>&1 || true
 fi
+
+# Claude is installed through a feature at build time and may be owned by root.
+# Normalize ownership so `claude update` works after deployment.
+repair_claude_install_permissions
 
 # Install crane (OCI utility) via Go if missing
 if ! command -v crane >/dev/null 2>&1; then


### PR DESCRIPTION
### Motivation
- The Claude CLI is installed at image build time and can be root-owned, which prevents the runtime user from performing `claude update` or other self-upgrade operations.
- Provisioning should normalize ownership of Claude-related install paths so upgrades work without manual chown steps.

### Description
- Added `repair_claude_install_permissions()` to `.devcontainer/scripts/post-create.sh` which detects the `claude` binary, resolves symlinks, and normalizes ownership with `chown -R` to the runtime user/group.
- The helper also inspects `npm` locations (`npm config get prefix` and `npm root -g`) and attempts to fix ownership of global npm directories and the `@anthropic-ai` package path when present.
- The new repair step is invoked during post-create provisioning (after Corepack enable) and respects the script `SUDO` helper so it works in privileged and unprivileged contexts.

### Testing
- Ran `bash -n .devcontainer/scripts/post-create.sh` which succeeded (syntax check passed).
- Ran `bash .devcontainer/scripts/validate-devcontainer.sh` which completed and produced environment diagnostics (it ran successfully but reported missing tools in this execution environment, which is expected outside a full devcontainer runtime).
- `shellcheck .devcontainer/scripts/post-create.sh` was skipped because `shellcheck` is not installed in this execution environment.
- `bash .devcontainer/scripts/validate-host.sh` was attempted and failed here due to missing `docker` in the runner (expected outside a host with Docker).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf72ce168832fa3e8cb5a6590fe8b)