### PR TITLE
Tune Dependabot: group updates, skip major feature bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,22 @@
 version: 2
 updates:
-  # Bump dev container feature versions (opens PRs; the controlled freshness off-ramp).
+  # Dev container features — grouped into one weekly PR. Skip major bumps; do those
+  # deliberately with `task devcontainer:upgrade:lock`.
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: "weekly"
-  # Keep the GitHub Actions used by CI current.
+    groups:
+      devcontainer-features:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  # GitHub Actions used by CI — grouped into one weekly PR.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Reduce Dependabot noise: group devcontainer-feature and github-actions updates into one weekly PR each, and skip major feature bumps (do those deliberately via `task devcontainer:upgrade:lock`).