### PR TITLE
Split CI (path-gated build) + disable oh-my-zsh config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": true,
       "installOhMyZsh": false,
+      "installOhMyZshConfig": false,
       "username": "vscode",
       "upgradePackages": true
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
-name: CI
+name: ShellCheck
 
 on:
   push:
     branches: [main]
+    paths: ['**.sh']
   pull_request:
+    paths: ['**.sh']
 
 jobs:
   shellcheck:
@@ -12,21 +14,3 @@ jobs:
       - uses: actions/checkout@v6
       - name: ShellCheck scripts
         run: shellcheck .devcontainer/scripts/*.sh install.sh
-
-  devcontainer:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Build and verify devcontainer
-        uses: devcontainers/ci@v0.3
-        with:
-          push: never
-          runCmd: |
-            set -e
-            echo "Verifying toolchain..."
-            go version
-            node --version
-            python3 --version
-            ruby --version
-            chezmoi --version
-            nvim --version | head -1

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -1,0 +1,29 @@
+name: Devcontainer Build
+
+# Heavy build — only runs when the dev container itself changes, so docs/config-only
+# PRs don't pay the ~15-minute build.
+on:
+  push:
+    branches: [main]
+    paths: ['.devcontainer/**']
+  pull_request:
+    paths: ['.devcontainer/**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and verify devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          runCmd: |
+            set -e
+            echo "Verifying toolchain..."
+            go version
+            node --version
+            python3 --version
+            ruby --version
+            chezmoi --version
+            nvim --version | head -1


### PR DESCRIPTION
Reduce CI cost: ShellCheck on script changes, heavy build only on `.devcontainer/**`. Also disable common-utils oh-my-zsh config so chezmoi fully owns ~/.zshrc.