### PR TITLE
Remove base-image ~/.oh-my-zsh (antidote replaces it)

### DIFF
--- a/.devcontainer/scripts/on-create.sh
+++ b/.devcontainer/scripts/on-create.sh
@@ -83,6 +83,10 @@ ensure_owned "${USER_HOME}/.local"
 ensure_user_dir "${USER_HOME}/.config"
 ensure_user_dir "${USER_HOME}/.local/bin"
 
+# The base image ships ~/.oh-my-zsh; this template uses antidote (via the user's
+# chezmoi dotfiles) instead, so drop the unused oh-my-zsh install.
+rm -rf "${USER_HOME}/.oh-my-zsh"
+
 restore_man_pages_if_needed
 
 # Enable corepack for pnpm/yarn if available


### PR DESCRIPTION
The devcontainers base image ships ~/.oh-my-zsh; this template uses antidote via chezmoi dotfiles, so on-create now removes the unused oh-my-zsh dir. Verified on the live container (dir removed, zsh still works).