### PR TITLE
SSH access via in-container sshd (SSH_AUTHORIZED_KEYS + port 2222)

### DIFF
--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -12,3 +12,7 @@
 
 # Override the container timezone (default: America/Sao_Paulo).
 # DEVCONTAINER_TZ=America/Los_Angeles
+
+# SSH public key(s) authorized for the in-container sshd on port 2222 (one per line).
+# This is a PUBLIC key, not a secret — but a Codespaces secret is a convenient way to inject it.
+# SSH_AUTHORIZED_KEYS="ssh-ed25519 AAAA... you@host"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -128,6 +128,13 @@
     "source=${localWorkspaceFolderBasename}-uv-cache,target=/home/vscode/.cache/uv,type=volume",
     "source=${localWorkspaceFolderBasename}-go-mod-cache,target=/home/vscode/.cache/go-mod,type=volume"
   ],
+  "forwardPorts": [2222],
+  "portsAttributes": {
+    "2222": {
+      "label": "ssh (in-container sshd)",
+      "onAutoForward": "silent"
+    }
+  },
   "onCreateCommand": "chmod +x .devcontainer/scripts/on-create.sh && .devcontainer/scripts/on-create.sh",
   "postCreateCommand": "chmod +x .devcontainer/scripts/post-create.sh && .devcontainer/scripts/post-create.sh",
   "postStartCommand": "chmod +x .devcontainer/scripts/post-start.sh && .devcontainer/scripts/post-start.sh",

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -145,6 +145,18 @@ apply_dotfiles_if_configured() {
   fi
 }
 
+authorize_ssh_keys() {
+  # Authorize key(s) for the in-container sshd (port 2222, via the sshd feature).
+  # SSH_AUTHORIZED_KEYS holds one or more public keys (newline-separated) — e.g. a
+  # Codespaces secret, or an entry in .devcontainer/devcontainer.env locally.
+  [ -n "${SSH_AUTHORIZED_KEYS:-}" ] || return 0
+  echo "🔑 Installing SSH authorized key(s) for the in-container sshd (port 2222)"
+  mkdir -p "${USER_HOME}/.ssh"
+  chmod 700 "${USER_HOME}/.ssh"
+  printf '%s\n' "${SSH_AUTHORIZED_KEYS}" >"${USER_HOME}/.ssh/authorized_keys"
+  chmod 600 "${USER_HOME}/.ssh/authorized_keys"
+}
+
 # Load local-only secrets/config for non-Codespaces runs (gitignored). Absent in
 # Codespaces, where PERSONAL_PAT / DOTFILES_REPO arrive as Codespaces secrets.
 if [ -f .devcontainer/devcontainer.env ]; then
@@ -231,6 +243,9 @@ if command -v gh >/dev/null 2>&1; then
     fi
   fi
 fi
+
+# Authorize SSH key(s) for the in-container sshd — only when SSH_AUTHORIZED_KEYS is set
+authorize_ssh_keys
 
 # Apply personal dotfiles (chezmoi) — only when DOTFILES_REPO is set
 apply_dotfiles_if_configured

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ they are injected automatically. For **local** runs, copy
 | `PERSONAL_PAT` | GitHub PAT for cross-repo git/gh auth (post-create runs `gh auth login`) |
 | `DOTFILES_REPO` | chezmoi dotfiles repo to auto-apply on create |
 | `DEVCONTAINER_TZ` | Container timezone (default `America/Sao_Paulo`) |
+| `SSH_AUTHORIZED_KEYS` | Public key(s) authorized for the in-container sshd on port 2222 — see [SSH access](#ssh-access) |
 
 > Secrets are intentionally **not** wired through `${localEnv:}` — in Codespaces that
 > resolves empty and would blank the injected secret.
@@ -104,6 +105,34 @@ git config --global user.email "you@example.com"
 ```
 
 If `gh` picks the wrong account: `unset GH_TOKEN GITHUB_TOKEN GH_AUTH_TOKEN`, then `gh auth login`.
+
+## SSH access
+
+Two ways to get a shell into the container:
+
+**`gh codespace ssh` (recommended for Codespaces)** — a GitHub-brokered tunnel; auth is your
+GitHub login, nothing to configure:
+
+```bash
+gh codespace ssh                      # pick a codespace
+gh codespace ssh -c <codespace-name>  # a specific one
+```
+
+**Raw SSH to the in-container sshd (port 2222)** — for tools/IDEs that need a real SSH
+endpoint (JetBrains Gateway, Remote-SSH, rsync, …). Provide your **public** key via
+`SSH_AUTHORIZED_KEYS` (a Codespaces secret, or `devcontainer.env` locally); `post-create`
+installs it to `~/.ssh/authorized_keys`. Then connect:
+
+```bash
+# Codespaces — forward 2222, then connect
+gh codespace ports forward 2222:2222 &
+ssh -p 2222 vscode@localhost
+
+# Local devcontainer in VS Code — 2222 is auto-forwarded
+ssh -p 2222 vscode@localhost
+```
+
+If you only ever use `gh codespace ssh`, the `sshd` feature is optional and can be removed.
 
 ## CI & validation
 


### PR DESCRIPTION
Wire up raw SSH: post-create installs `SSH_AUTHORIZED_KEYS` (Codespaces secret / devcontainer.env) into authorized_keys; forward 2222; docs. Validated end-to-end — real key-auth handshake to sshd:2222 succeeds and the full toolchain resolves over SSH.